### PR TITLE
begin hooking it up with addis api

### DIFF
--- a/app.js
+++ b/app.js
@@ -10,9 +10,8 @@ const router = express.Router()
 
 // Import sample data
 const community = require('./data/community')
-const communityInspections = require('./data/community-inspections')
-const travelers = require('./data/travelers')
-
+// const travelers = require('./data/travelers')
+const covidAddisApi = require('./covidAddisApi')
 app.set('view engine', 'pug')
 
 if (process.env.NODE_ENV === 'test') {
@@ -44,11 +43,11 @@ router.get('/covid19et', (req, res) => {
 })
 
 // API Abstraction
-router.get('/v1/:type/:id?', (req, res) => {
+router.get('/v1/:type/:id?', async (req, res) => {
   const type = req.params.type
   if (!type) return res.status(404).json({})
 
-  let data = ''
+  let data = []
 
   switch (type) {
     case 'community':
@@ -56,11 +55,12 @@ router.get('/v1/:type/:id?', (req, res) => {
       break
 
     case 'community-inspections':
-      data = communityInspections
+      data = await covidAddisApi.communityInspections()
       break
 
     case 'travelers':
-      data = travelers
+
+      data = await covidAddisApi.getTravelers()
       break
 
     default:
@@ -75,12 +75,38 @@ router.get('/v1/:type/:id?', (req, res) => {
     console.log(id)
     const getRecord = id => data.find(r => r.id === parseInt(id))
 
-    data = getRecord(id)
+    data = getRecord(id) || {}
   }
 
-  return res.json(data)
+  return res.send(data)
 })
 
+router.post('/v1/:type', async (req, res) => {
+  const type = req.params.type
+  if (!type) return res.status(404).send(false)
+
+  let data = false
+
+  switch (type) {
+    case 'community':
+      data = false
+      break
+
+    case 'community-inspections':
+      data = false
+      break
+
+    case 'travelers':
+      data = await covidAddisApi.addTraveler(req.body)
+      break
+
+    default:
+      data = false
+      break
+  }
+
+  return res.send(data)
+})
 router.post('/users', (req, res) => {
   const user = {
     id: ++userIdCounter,
@@ -107,6 +133,7 @@ router.delete('/users/:userId', (req, res) => {
   users.splice(userIndex, 1)
   res.json(users)
 })
+
 
 //
 

--- a/covidAddisApi.js
+++ b/covidAddisApi.js
@@ -1,0 +1,36 @@
+const axios = require('axios')
+
+const hosts = {
+  travel: 'https://covidtravelreg.api.sandboxaddis.com/api/Travllers',
+  communityInsepections: 'https://covidtollfreereg.api.sandboxaddis.com/api'
+}
+
+const requestGet = async (host, uri) => {
+  try {
+    const result = await axios.get(`${host}/${uri}`)
+    return result.data
+  } catch (error) {
+    console.error('get error ', error)
+  }
+  return []
+}
+
+const getTravelers = async (host, ur) => {
+  return requestGet(hosts.travel, 'GetAll')
+}
+
+const addTraveler = async (data) => {
+  const result = await axios.post(`${hosts.travel}/AddTravler`, data)
+  return result.data
+}
+
+const communityInspections = async () => {
+    // TODO: pass token
+  return requestGet(hosts.communityInsepections, 'CommunityInspections')
+}
+
+module.exports = {
+  getTravelers,
+  addTraveler,
+  communityInspections
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -115,6 +115,14 @@
         "type-is": "^1.6.16"
       }
     },
+    "axios": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
+      "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+      "requires": {
+        "follow-redirects": "1.5.10"
+      }
+    },
     "babel-runtime": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
@@ -597,6 +605,24 @@
         "parseurl": "~1.3.3",
         "statuses": "~1.5.0",
         "unpipe": "~1.0.0"
+      }
+    },
+    "follow-redirects": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+      "requires": {
+        "debug": "=3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "forwarded": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "aws-serverless-express": "^3.3.3",
+    "axios": "^0.19.2",
     "body-parser": "^1.17.1",
     "compression": "^1.6.2",
     "cors": "^2.8.3",


### PR DESCRIPTION
As you had demonstrated in last nights meetup, I've hooked up `getTravelers` and `addTraveler` with the addis api. `communityInspections` still requires header configuration.
 This might possibly be a duplicate/conflict effort so feel free to close it w/o merging. I am hoping this will give me an entry point.

- Get all with `getTravelers`
<img width="1210" alt="Screen Shot 2020-03-24 at 1 17 25 AM" src="https://user-images.githubusercontent.com/1224206/77395163-f86dd880-6d6e-11ea-9ce4-403b0c300d6a.png">

- Get a single travler with `getTravelers` by id
<img width="979" alt="Screen Shot 2020-03-24 at 1 18 11 AM" src="https://user-images.githubusercontent.com/1224206/77395164-f9066f00-6d6e-11ea-88b0-2acfc6afbf15.png">

- Post with `addTraveler`

<img width="724" alt="Screen Shot 2020-03-24 at 1 32 18 AM" src="https://user-images.githubusercontent.com/1224206/77395375-6f0ad600-6d6f-11ea-9bd0-8298ef2f8475.png">
